### PR TITLE
Use CP437 encoding

### DIFF
--- a/client.rb
+++ b/client.rb
@@ -34,7 +34,7 @@ Date: <%= created_at %>
 def print_order(order)
   orderstruct = OpenStruct.new(order)
   text = ERB.new(@template).result(orderstruct.instance_eval { binding })
-  File.open("/dev/ttyUSB0", "w") { |file| file.write(text.encode(Encoding::CP437)) }
+  File.open("/dev/ttyUSB0", "w") { |file| file.write(text.encode(Encoding::CP437, invalid: :replace, undef: :replace)) }
 end
 
 puts "declare connection"

--- a/client.rb
+++ b/client.rb
@@ -34,7 +34,7 @@ Date: <%= created_at %>
 def print_order(order)
   orderstruct = OpenStruct.new(order)
   text = ERB.new(@template).result(orderstruct.instance_eval { binding })
-  File.open("/dev/ttyUSB0", "w") { |file| file.write(text) }
+  File.open("/dev/ttyUSB0", "w") { |file| file.write(text.encode(Encoding::CP437)) }
 end
 
 puts "declare connection"


### PR DESCRIPTION
I think this is the default encoding for Epson TM printers (It's definitely not UTF-8, which is not supported).

Please test this before merging, I don't have a printer to test myself.

Equivalent shell code:

```shell
echo "Späti" | iconv -f UTF-8 -t CP437 > /dev/ttyUSB0
```

-----

If the default charset turns out _not_ to be CP437, we might need to first send a [ESC/POS command](http://content.epson.de/fileadmin/content/files/RSD/downloads/escpos.pdf#page12) to set it.

Depending on the device, other charsets might be available, but CP437 is the one with ASCII and the most common Non-ASCII characters.